### PR TITLE
Update README to use SkyResult in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Now open up your `src/main.rs` file and establish a connection to the server whi
 imports:
 
 ```rust
-use skytable::{Connection, Query, Element};
-fn main() -> std::io::Result<()> {
+use skytable::{Connection, Query, Element, SkyResult};
+fn main() -> SkyResult<()> {
     let mut con = Connection::new("127.0.0.1", 2003)?;
     Ok(())
 }


### PR DESCRIPTION
Thank you for your work on SkyTable.
When looking at the Rust Client, I noticed the current example code, did not compile because of the Result return type.

use skytable::{Connection, Query, Element};
fn main() -> std::io::Result<()> {
    let mut con = Connection::new("127.0.0.1", 2003)?;
    Ok(())
}

I updated the example to use 'SkyResult' instead.

Thank you
Nelius




