### PR TITLE
Adds impl FromSkyhashBytes for RawString and a TODO

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -399,6 +399,16 @@ impl<'a> IntoSkyhashBytes for &'a RawString {
     }
 }
 
+impl FromSkyhashBytes for RawString {
+    fn from_element(element: Element) -> SkyResult<RawString> {
+        let e = match element {
+            Element::Binstr(bstr) => bstr.into(),
+            _ => return Err(Error::ParseError(BAD_ELEMENT.to_owned())),
+        };
+        Ok(e)
+    }
+}
+
 /// Implementing this trait enables Skyhash [elements](crate::Element) to be converted
 /// into Rust types. This trait is already implemented for most primitive types, but for
 /// your own custom types, you'll need to implement it yourself.
@@ -459,6 +469,9 @@ macro_rules! impl_from_skyhash {
         $(impl FromSkyhashBytes for $ty {
             fn from_element(element: Element) -> SkyResult<$ty> {
                 let ret = match element {
+                    // Note: We're assuming primitive types are internally
+                    // represented as strings, which we then parse.
+                    // TODO: Represent primitives more efficiently.
                     Element::Binstr(bstr) => String::from_utf8_lossy(&bstr).parse::<$ty>()?,
                     Element::String(st) => st.parse::<$ty>()?,
                     Element::UnsignedInt(int) => int.try_into()?,


### PR DESCRIPTION
This is just a code sketch, as I'm a bit unclear on a couple things:

1. I'm not sure why this wasn't already included (and I assume you have a good reason).
1. I don't understand why you're encoding the key / value data the way you are. For example, in line 475 you seem to assume primitives are encoded as UTF8 strings, which seems very odd. Rather I'd expect everything in the DB to be (arbitrary, not UTF8) `Vec<u8>`s. I think you can convert all these primitives to bytes using functions like `_.to_le_bytes()`.

Relatedly, I'm not sure why you need the `RawString` type instead of just implementing the appropriate traits for `Vec<u8>`.