### PR TITLE
Added Clone trait to Query in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -502,7 +502,7 @@ macro_rules! query {
 /// }
 /// ```
 ///
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Query {
     size_count: usize,
     data: Vec<u8>,


### PR DESCRIPTION
In a multi-threaded scenario sometimes may be necessary to move Query objects between threads.
By adding the trait to the struct it is possible to fully leverage tokio runtime capabilities.