### PR TITLE
Fixed comment/doc title that called the Sync pool the async pool

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -30,7 +30,7 @@
 //!     let mut db = pool.get().await.unwrap();
 //! }
 //! ```
-//! ### Creating a async pool
+//! ### Creating a sync pool
 //! ```no_run
 //! use skytable::{pool, Config};
 //!


### PR DESCRIPTION
how to create the sync pool was labeled as async when it should be labeled as sync so theres actually 2 creating a async pool atm. first the real one then the one that should be called sync shown below.
